### PR TITLE
Update email template for handling @mentions

### DIFF
--- a/server/src/api/webhooks.ts
+++ b/server/src/api/webhooks.ts
@@ -122,7 +122,7 @@ export const handleWebhook = async (req: Request, res: Response, next: NextFunct
                             break;
                         }
                         case 'textMention': {
-                            notificationMessage = `You were mentioned in room ${roomId}`;
+                            notificationMessage = "You have been @mentioned in a comment on VERDAD.app";
                             templateName = 'mention_notification';
                             await sendSlackNotification({
                                 type: 'mention',
@@ -149,6 +149,8 @@ export const handleWebhook = async (req: Request, res: Response, next: NextFunct
                         .replace('{{notificationMessage}}', notificationMessage)
                         .replace('{{roomId}}', roomId)
                         .replace('{{additionalContent}}', '')
+                        .replace('{{commentBody}}', inboxNotification.body || '')
+                        .replace('{{link}}', `https://verdad.app/snippet/${roomId}`)
                     : `<!DOCTYPE html><html><body><p>${notificationMessage}</p></body></html>`;
 
                 await sendEmail(

--- a/server/src/services/templateService.ts
+++ b/server/src/services/templateService.ts
@@ -19,3 +19,15 @@ export async function getEmailTemplate(templateName: string) {
 
     return data?.template_content;
 }
+
+export async function getMentionNotificationTemplate() {
+    const template = await getEmailTemplate('mention_notification');
+    if (!template) {
+        return null;
+    }
+
+    return template
+        .replace('{{subject}}', 'You have been @mentioned in a comment on VERDAD.app')
+        .replace('{{commentBody}}', '{{commentBody}}')
+        .replace('{{link}}', 'https://verdad.app/snippet/{{roomId}}');
+}


### PR DESCRIPTION
Update email notification template for handling @mentions to include the message contents and a link to the snippet detail page

* Modify `server/src/services/templateService.ts` to add a new function `getMentionNotificationTemplate` that includes placeholders for the subject, comment body, and link.
* Update `server/src/api/webhooks.ts` to set the notification message to "You have been @mentioned in a comment on VERDAD.app" and replace placeholders with actual comment body and URL in the email content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PublicDataWorks/verdad/pull/5?shareId=9c90a1a6-c397-440f-b18a-62722864b85f).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced webhook event handling for more specific notifications, including a tailored mention message.
	- Expanded email content to include comment bodies and links to specific snippets on VERDAD.app.
	- Introduced a new function to retrieve and customize mention notification email templates.

- **Bug Fixes**
	- Improved error handling for missing data in notification events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->