### PR TITLE
[f] VER-262 - Denormalize label upvote count

### DIFF
--- a/supabase/database/sql/get_snippets_function.sql
+++ b/supabase/database/sql/get_snippets_function.sql
@@ -290,19 +290,12 @@ BEGIN
                 WHEN p_language = 'spanish' THEN l.text_spanish
                 ELSE l.text
             END AS text,
-            COALESCE(lu.upvote_count, 0) AS upvote_count,
-            COALESCE(lu.upvoted_by_me, FALSE) AS upvoted_by_me,
+            sl.upvote_count,
+            lu.id IS NOT NULL AS upvoted_by_me,
             sl.snippet AS snippet_id
         FROM snippet_labels sl
         JOIN labels l ON l.id = sl.label
-        LEFT JOIN (
-            SELECT
-                snippet_label,
-                COUNT(*) AS upvote_count,
-                BOOL_OR(upvoted_by = current_user_id) AS upvoted_by_me
-            FROM label_upvotes lu
-            GROUP BY snippet_label
-        ) lu ON lu.snippet_label = sl.id
+        LEFT JOIN label_upvotes lu ON lu.snippet_label = sl.id AND lu.upvoted_by = current_user_id
         WHERE sl.snippet IN (SELECT id FROM paginated_snippets)
     ),
     paginated_snippets_with_labels AS (

--- a/supabase/database/sql/label_upvote_count_migration.sql
+++ b/supabase/database/sql/label_upvote_count_migration.sql
@@ -1,0 +1,11 @@
+WITH label_upvote_counts AS (
+    SELECT
+      snippet_label AS snippet_label_id,
+      COUNT(*) AS total_upvotes
+    FROM label_upvotes
+    GROUP BY snippet_label
+)
+UPDATE snippet_labels sl
+SET upvote_count = COALESCE(luc.total_upvotes, 0)
+FROM label_upvote_counts luc
+WHERE sl.id = luc.snippet_label_id;

--- a/supabase/database/sql/update_snippet_upvote_count.sql
+++ b/supabase/database/sql/update_snippet_upvote_count.sql
@@ -2,10 +2,21 @@ CREATE OR REPLACE FUNCTION update_snippet_upvote_count()
 RETURNS TRIGGER AS $$
 DECLARE
     snippet_id UUID;
+    snippet_label_id UUID;
 BEGIN
+    snippet_label_id := COALESCE(NEW.snippet_label, OLD.snippet_label);
+
     SELECT snippet INTO snippet_id
     FROM snippet_labels
     WHERE id = COALESCE(NEW.snippet_label, OLD.snippet_label);
+
+    UPDATE snippet_labels
+    SET upvote_count = (
+        SELECT COUNT(*)
+        FROM label_upvotes
+        WHERE snippet_label = snippet_label_id
+    )
+    WHERE id = snippet_label_id;
 
     IF snippet_id IS NOT NULL THEN
         UPDATE snippets

--- a/supabase/database/sql/update_snippet_upvote_count.sql
+++ b/supabase/database/sql/update_snippet_upvote_count.sql
@@ -6,17 +6,14 @@ DECLARE
 BEGIN
     snippet_label_id := COALESCE(NEW.snippet_label, OLD.snippet_label);
 
-    SELECT snippet INTO snippet_id
-    FROM snippet_labels
-    WHERE id = COALESCE(NEW.snippet_label, OLD.snippet_label);
-
     UPDATE snippet_labels
     SET upvote_count = (
         SELECT COUNT(*)
         FROM label_upvotes
         WHERE snippet_label = snippet_label_id
     )
-    WHERE id = snippet_label_id;
+    WHERE id = snippet_label_id
+    RETURNING snippet INTO snippet_id;
 
     IF snippet_id IS NOT NULL THEN
         UPDATE snippets

--- a/supabase/database/sql/update_upvote_count_trigger.sql
+++ b/supabase/database/sql/update_upvote_count_trigger.sql
@@ -1,0 +1,4 @@
+CREATE TRIGGER update_upvote_count
+AFTER INSERT OR DELETE ON label_upvotes
+FOR EACH ROW
+EXECUTE FUNCTION update_snippet_upvote_count();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Denormalizes label upvote count by updating SQL functions and triggers to ensure real-time updates and efficient retrieval.
> 
>   - **Behavior**:
>     - Denormalizes label upvote count by updating `get_snippets_function.sql` to directly use `snippet_labels.upvote_count`.
>     - Adds `label_upvote_count_migration.sql` to initialize `upvote_count` in `snippet_labels`.
>     - Updates `update_snippet_upvote_count.sql` to recalculate `upvote_count` on `label_upvotes` changes.
>     - Introduces `update_upvote_count_trigger.sql` to trigger `update_snippet_upvote_count()` after `label_upvotes` insertions or deletions.
>   - **Functions**:
>     - Modifies `get_snippets_function.sql` to remove inline upvote count calculation and use pre-calculated `upvote_count`.
>     - Adds `update_snippet_upvote_count()` to update `upvote_count` in `snippet_labels` and `snippets`.
>   - **Triggers**:
>     - Adds `update_upvote_count_trigger` to ensure `upvote_count` is updated in real-time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PublicDataWorks%2Fverdad&utm_source=github&utm_medium=referral)<sup> for 8a7f04138d24d8d315d31b41b718335abfffe8e0. You can [customize](https://app.ellipsis.dev/PublicDataWorks/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->